### PR TITLE
Issue #12: Open _Add inventory_ form in a modal

### DIFF
--- a/modules/custom/nfafmis/js/nfafmis.local.js
+++ b/modules/custom/nfafmis/js/nfafmis.local.js
@@ -37,7 +37,7 @@
         filterHarvestTab.append(filterSubElem);
 
         // Add inventory link.
-        let addInventroyElem = `<a class="btn btn-info btn-xs"
+        let addInventroyElem = `<a class="use-ajax btn btn-info btn-xs"
         data-dialog-options="{&quot;width&quot;:800}" data-dialog-type="modal"
         id="add-invenotry-btn">Add Inventory</a>`;
         filterInventoryTab.append(addInventroyElem);


### PR DESCRIPTION
## Description

This PR adds the `use-ajax` class to the **Add Inventory** link so it can be properly loaded inside the modal window.

## Testing Instructions

* Go to `/tree-farmer-overview/inventory`
* Click "Add Inventory"
* Verify the form is opened inside a modal window
* Enter values and save the form. Check the saved values are stored as expected.