### PR TITLE
Issue #14: Open _Add Harvest_ form in modal

### DIFF
--- a/modules/custom/nfafmis/js/nfafmis.local.js
+++ b/modules/custom/nfafmis/js/nfafmis.local.js
@@ -43,7 +43,7 @@
         filterInventoryTab.append(addInventroyElem);
 
         // Add Harvest link.
-        let addHarvestElem = `<a class="btn btn-info btn-xs"
+        let addHarvestElem = `<a class="use-ajax btn btn-info btn-xs"
         data-dialog-options="{&quot;width&quot;:800}" data-dialog-type="modal"
         id="add-harvest-btn">Add Harvest</a>`;
         filterHarvestTab.append(addHarvestElem);


### PR DESCRIPTION
## Description

This PR adds the `use-ajax` class to the **Add Harvest** link so it can be properly loaded inside the modal window.

## Testing Instructions

* Go to `/tree-farmer-overview/harvest?title=Test%20farmer`
* Click "Add Harvest"
* Verify the form is opened inside a modal window
* Enter values and save the form. Check the saved values are stored as expected.