### PR TITLE
Issue #4: Open _Add log_ form in a modal

### DIFF
--- a/sites/default/config/views.view.farmer_main_tab.yml
+++ b/sites/default/config/views.view.farmer_main_tab.yml
@@ -601,7 +601,7 @@ display:
           exclude: true
           alter:
             alter_text: true
-            text: '<a class="btn btn-info btn-xs" href="{{ view_node }}#comment-form&destination=/tree-farmer-overview">Add a log</a>'
+            text: '<a class="use-ajax btn btn-info btn-xs" data-dialog-options="{&quot;width&quot;:800}" data-dialog-type="modal" href="/comment/reply/node/{{nid}}/comment">Add a log</a>'
             make_link: false
             path: ''
             absolute: false


### PR DESCRIPTION
## Description

This PR changes the **Add log** button so that it loads only the comment form in a modal window.

## Testing Instructions

* Go to `/tree-farmer-overview?title=Test+farmer`
* Click "Add log"
* Verify that only the comment (log) form is opened inside a modal window
* Enter values and save the form. Check the saved values are stored as expected.