### PR TITLE
Issue #5: Refresh log views after flagging a log

### DIFF
--- a/modules/custom/nfafmis/js/nfafmis.local.js
+++ b/modules/custom/nfafmis/js/nfafmis.local.js
@@ -7,6 +7,15 @@
   Drupal.behaviors.nfamis = {
     attach: function(context, settings) {
 
+      // Whenever a farmer log flag is triggered, make sure views whose content
+      // might need to update are also refreshed.
+      $('.view-flagged-farmer-log .flag a').on('click', function (e) {
+        $(this)
+          .closest('.view-farmer-main-tab')
+          .find('.view-flagged-farmer-log')
+          .trigger('RefreshView');
+      });
+
       $(".sub-areas-planting", context).once("nfamis").each(function() {
 
         let filterSubAreaTab = $(this).find('.center-container .area-filter-sub-area-tab');

--- a/sites/default/config/views.view.farmer_main_tab.yml
+++ b/sites/default/config/views.view.farmer_main_tab.yml
@@ -353,6 +353,7 @@ display:
         filters: true
         filter_groups: true
         header: false
+        use_ajax: false
       display_description: ''
       fields:
         title_1:
@@ -707,6 +708,7 @@ display:
             value: '{{ view_node }}'
             format: full_html
           plugin_id: text
+      use_ajax: true
     cache_metadata:
       max-age: -1
       contexts:

--- a/sites/default/config/views.view.flagged_farmer_log.yml
+++ b/sites/default/config/views.view.flagged_farmer_log.yml
@@ -703,6 +703,7 @@ display:
           entity_field: nid
           plugin_id: node_nid
       display_extenders: {  }
+      use_ajax: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -1374,7 +1375,20 @@ display:
           hide_alter_empty: false
           plugin_id: custom
       header: {  }
-      empty: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: true
+          content:
+            value: '<h5 class="title">Flagged Farmer logs</h5>'
+            format: basic_html
+          plugin_id: text
       css_class: view-label-data
     cache_metadata:
       max-age: -1


### PR DESCRIPTION
## Description

This adds a kind of workaround for the fact that flag links don't trigger a full refresh on the views they belong to. We listen to clicks on the flag links and then manually refresh the views we are interested in.

This approach isn't ideal, but I'm unsure to what extent a big refactor would be justified for this issue. Happy to discuss it further if necessary.

## Testing Instructions

* Navigate to `/tree-farmer-overview?title=Test+farmer`
* Click on the link to Flag (or Unflag) a log entry. Verify that entry moves to the other column without a page refresh. 
* Reload the page, and check it remains in the new column