### PR TITLE
Issue #6: Remove _Add receipt_ button from tree farmer overview view

### DIFF
--- a/sites/default/config/views.view.tree_farmer_overview.yml
+++ b/sites/default/config/views.view.tree_farmer_overview.yml
@@ -835,7 +835,7 @@ display:
           empty: true
           tokenize: false
           content:
-            value: "<div class=\"block-section\">\r\n  <h5 class=\"title\">Key data</h5>\r\n<p><a class=\"use-ajax btn btn-info btn-xs\" data-dialog-options=\"{&quot;width&quot;:800}\" data-dialog-type=\"modal\" href=\"/node/add/fee_payment_nfa\">Add a receipt</a></p>\r\n</div>\r\n"
+            value: "<div class=\"block-section\">\r\n  <h5 class=\"title\">Key data</h5>\r\n</div>\r\n"
             format: full_html
           plugin_id: text
       css_class: view-label-data


### PR DESCRIPTION
## Description

This PR removes part of the markup being used in the view, used to create an **Add receipt** AJAX link.

Note: There is additional markup in that view area ( "Key Data" ), that feels a bit odd. Since the ticket doesn't mention anything about it, it was left as is.

## Testing Instructions

* Navigate to `/tree-farmer-overview?title=Test+farmer`
* Verify you no longer have a "Add receipt" button available