### PR TITLE
Issue #7: Disallow administering comments from non-admin users

### DIFF
--- a/sites/default/config/user.role.nfa_staff.yml
+++ b/sites/default/config/user.role.nfa_staff.yml
@@ -9,7 +9,6 @@ is_admin: null
 permissions:
   - 'access content'
   - 'administer comment types'
-  - 'administer comments'
   - 'create accounts_detail content'
   - 'create accounts_simplication_temporary content'
   - 'create annual_charges content'

--- a/sites/default/config/user.role.not_staff.yml
+++ b/sites/default/config/user.role.not_staff.yml
@@ -9,7 +9,6 @@ is_admin: null
 permissions:
   - 'access content'
   - 'administer comment types'
-  - 'administer comments'
   - 'create accounts_detail content'
   - 'create accounts_simplication_temporary content'
   - 'create annual_charges content'


### PR DESCRIPTION
## Description

Even though the ticket summary mentions Revision Information, Menu settings, etc, I was only able to reproduce this with for the "Comment settings" fieldset.

This PR removes permission to administer comments on non-Admin roles (`nfa_staff` and `not_staff`). This is enough for preventing the fieldset from being added to node forms. I'm unaware, however, if it is expected that those roles should be able to administer comments but not have the fieldset on the node form. If that was the case, we can leave the permissions on and implement a form_alter to just remove the widget from the form.

## Testing Instructions

* Log in as a non-admin user
* Open some forms that create or edit content, verify you no longer have the "Comment settings" fieldset at the bottom of the form inside the modal window.