### PR TITLE
#203: added download links field   

### DIFF
--- a/config/sync/core.entity_form_display.node.offer_license.default.yml
+++ b/config/sync/core.entity_form_display.node.offer_license.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.offer_license.documents
     - field.field.node.offer_license.field_area_number
     - field.field.node.offer_license.field_area_serial_number
     - field.field.node.offer_license.field_block_ref
@@ -21,12 +22,20 @@ dependencies:
   module:
     - datetime
     - datetime_range
+    - file
     - serial
 id: node.offer_license.default
 targetEntityType: node
 bundle: offer_license
 mode: default
 content:
+  documents:
+    type: file_generic
+    weight: 26
+    region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
   field_area_serial_number:
     type: serial_default_widget
     weight: 12

--- a/config/sync/core.entity_view_display.node.offer_license.default.yml
+++ b/config/sync/core.entity_view_display.node.offer_license.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.offer_license.documents
     - field.field.node.offer_license.field_area_number
     - field.field.node.offer_license.field_area_serial_number
     - field.field.node.offer_license.field_block_ref
@@ -21,6 +22,7 @@ dependencies:
   module:
     - datetime
     - datetime_range
+    - file
     - serial
     - user
 id: node.offer_license.default
@@ -28,6 +30,14 @@ targetEntityType: node
 bundle: offer_license
 mode: default
 content:
+  documents:
+    type: file_default
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    weight: 15
+    region: content
   field_area_number:
     type: string
     label: above

--- a/config/sync/core.entity_view_display.node.offer_license.report_row.yml
+++ b/config/sync/core.entity_view_display.node.offer_license.report_row.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.report_row
+    - field.field.node.offer_license.documents
     - field.field.node.offer_license.field_area_number
     - field.field.node.offer_license.field_area_serial_number
     - field.field.node.offer_license.field_block_ref
@@ -105,6 +106,7 @@ content:
     weight: 0
     region: content
 hidden:
+  documents: true
   field_area_number: true
   field_area_serial_number: true
   field_central_forest_reserve: true

--- a/config/sync/core.entity_view_display.node.offer_license.teaser.yml
+++ b/config/sync/core.entity_view_display.node.offer_license.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.offer_license.documents
     - field.field.node.offer_license.field_area_number
     - field.field.node.offer_license.field_area_serial_number
     - field.field.node.offer_license.field_block_ref
@@ -32,6 +33,7 @@ content:
     weight: 100
     region: content
 hidden:
+  documents: true
   field_area_number: true
   field_area_serial_number: true
   field_block_ref: true

--- a/config/sync/field.field.node.offer_license.documents.yml
+++ b/config/sync/field.field.node.offer_license.documents.yml
@@ -1,0 +1,27 @@
+uuid: 9dd699b1-56b8-4c9a-8529-5b11b9dd30e0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.documents
+    - node.type.offer_license
+  module:
+    - file
+id: node.offer_license.documents
+field_name: documents
+entity_type: node
+bundle: offer_license
+label: Documents
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: pdf
+  max_filesize: ''
+  description_field: false
+field_type: file

--- a/config/sync/field.storage.node.documents.yml
+++ b/config/sync/field.storage.node.documents.yml
@@ -1,0 +1,23 @@
+uuid: 6bc91037-4a35-4d65-9361-ba200e925e41
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - node
+id: node.documents
+field_name: documents
+entity_type: node
+type: file
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: file
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.offers_licences_view.yml
+++ b/config/sync/views.view.offers_licences_view.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.documents
     - field.storage.node.field_area_number
     - field.storage.node.field_block_ref
     - field.storage.node.field_central_forest_reserve
@@ -17,6 +18,7 @@ dependencies:
   module:
     - datetime
     - datetime_range
+    - file
     - nfafmis
     - node
     - user
@@ -1648,6 +1650,69 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        documents:
+          id: documents
+          table: node__documents
+          field: documents
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: 'Download Links'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: file_default
+          settings:
+            use_description_as_link_text: true
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       defaults:
         fields: false
         header: false
@@ -1676,6 +1741,7 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.documents'
         - 'config:field.storage.node.field_area_number'
         - 'config:field.storage.node.field_block_ref'
         - 'config:field.storage.node.field_central_forest_reserve'

--- a/config/sync/views.view.offers_licences_view.yml
+++ b/config/sync/views.view.offers_licences_view.yml
@@ -664,7 +664,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: numeric
+          plugin_id: entity_target_id
           default_action: default
           exception:
             value: all
@@ -690,6 +690,7 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
+          target_entity_type_id: node
       filters:
         status:
           id: status
@@ -1658,7 +1659,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: 'Download Links'
+          label: Documents
           exclude: false
           alter:
             alter_text: false
@@ -1702,7 +1703,7 @@ display:
           click_sort_column: target_id
           type: file_default
           settings:
-            use_description_as_link_text: true
+            use_description_as_link_text: false
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -1711,7 +1712,7 @@ display:
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: '<br>   '
           field_api_classes: false
       defaults:
         fields: false


### PR DESCRIPTION
added file upload to Offer/License and download links row on the Offer/License tab in the Land Allocations table

demo:

https://github.com/user-attachments/assets/4f40e581-33df-4440-8af9-fbea63c05b47











